### PR TITLE
ci: upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18' # Use a stable version of Node.js
 
@@ -27,7 +27,7 @@ jobs:
       run: npm run build
 
     - name: Upload Installer Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ai-assistant-installer
-        path: release/AI Assistant Setup 1.0.0.exe
+        path: "release/AI Assistant Setup 1.0.0.exe"


### PR DESCRIPTION
## Changes

This PR upgrades deprecated GitHub Actions to their latest v4 versions:

- ✅ ctions/upload-artifact@v3 → ctions/upload-artifact@v4
- ✅ ctions/checkout@v3 → ctions/checkout@v4  
- ✅ ctions/setup-node@v3 → ctions/setup-node@v4

## Why this fixes the failure

GitHub now rejects ctions/upload-artifact@v3. Upgrading to v4 resolves the runner error shown in the workflow logs.

## Testing

- [x] All action versions updated to v4
- [x] No other v3 references found in workflow files
- [x] Will re-run workflow after merge to confirm fix

## References

- [upload-artifact v4 migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
- [Workflow run](https://github.com/thenursesstation00-svg/AI-Assistant/actions)